### PR TITLE
Remove deprecated startup and shutdown methods 

### DIFF
--- a/src-st/OpenSSL-Core.package/LcLibCrypto.class/class/initialize.st
+++ b/src-st/OpenSSL-Core.package/LcLibCrypto.class/class/initialize.st
@@ -3,4 +3,3 @@ initialize
 
 	self reset.
 	self initializeTypeMap.
-	Smalltalk addToStartUpList: self; addToShutDownList: self

--- a/src-st/OpenSSL-Core.package/LcLibCrypto.class/class/shutDown..st
+++ b/src-st/OpenSSL-Core.package/LcLibCrypto.class/class/shutDown..st
@@ -1,6 +1,0 @@
-system startup
-shutDown: quitting
-
-	quitting ifTrue: [ 
-		self current apiCryptoCleanupAllData.
-		self current apiFreeErrorStrings  ]

--- a/src-st/OpenSSL-Core.package/LcLibCrypto.class/class/startUp..st
+++ b/src-st/OpenSSL-Core.package/LcLibCrypto.class/class/startUp..st
@@ -1,3 +1,0 @@
-system startup
-startUp: resuming
-	resuming ifTrue: [ self current apiLoadErrorStrings  ]

--- a/src-st/OpenSSL-Core.package/LcLibCrypto.class/instance/apiCryptoCleanupAllData.st
+++ b/src-st/OpenSSL-Core.package/LcLibCrypto.class/instance/apiCryptoCleanupAllData.st
@@ -1,4 +1,0 @@
-private - API - library
-apiCryptoCleanupAllData
-	^ self ffiCall: #(void CRYPTO_cleanup_all_ex_data (void))
-		module: self library

--- a/src-st/OpenSSL-Core.package/LcLibCrypto.class/instance/apiFreeErrorStrings.st
+++ b/src-st/OpenSSL-Core.package/LcLibCrypto.class/instance/apiFreeErrorStrings.st
@@ -1,4 +1,0 @@
-private - API - error
-apiFreeErrorStrings
-	^ self ffiCall: #(void ERR_free_strings (void))
-		module: self library

--- a/src-st/OpenSSL-Core.package/LcLibCrypto.class/instance/apiLoadErrorStrings.st
+++ b/src-st/OpenSSL-Core.package/LcLibCrypto.class/instance/apiLoadErrorStrings.st
@@ -1,4 +1,0 @@
-private - API - error
-apiLoadErrorStrings
-	^ self ffiCall: #(void ERR_load_crypto_strings (void))
-		module: self library


### PR DESCRIPTION
Hi Pierce,

This removes calls to `ERR_load_crypto_strings`. `CRYPTO_cleanup_all_ex_data()` and `ERR_free_strings` that were deprecated (in OpenSSL 1.1.0, I think).

In OpenSSL 1.1.1 they are C macros, which obviously can't be called from FFI, so fail completely.


See:

https://www.openssl.org/docs/man1.1.0/man3/OPENSSL_init_crypto.html
https://www.openssl.org/news/cl110.txt