### PR TITLE
Fix LcLibCrypto>>apiVersion: which previously attempted to call a C macro

### DIFF
--- a/src-st/OpenSSL-Core.package/LcLibCrypto.class/instance/apiVersion..st
+++ b/src-st/OpenSSL-Core.package/LcLibCrypto.class/instance/apiVersion..st
@@ -1,4 +1,4 @@
 private - API - library
 apiVersion: flag
-	^ self ffiCall: #(String SSLeay_version (int flag))
+	^ self ffiCall: #(String OpenSSL_version (int flag))
 		module: self library


### PR DESCRIPTION
Hi Pierce,

In OpenSSL 1.1.1 `SSLeay_version()` is a C macro, so obviously can't be called from FFI.  `OpenSSL_version()` looks like the replacement.

HTH,
Alistair