### PR TITLE
Made changes to deprecated method #moduleName -> #libraryName

### DIFF
--- a/src-st/OpenSSL-Core.package/LcLibCrypto.class/instance/library.st
+++ b/src-st/OpenSSL-Core.package/LcLibCrypto.class/instance/library.st
@@ -1,3 +1,3 @@
 private - accessing
 library
-	^ self moduleName
+	^ self libraryName


### PR DESCRIPTION
LibLcCrypto crashes in P9 at the moment, but this was all that was needed to fix it